### PR TITLE
[ID-64]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Sort Order when showing all (public) surveys [#64](https://github.com/rokwire/surveys-building-block/issues/64)
+
 ## [1.9.0] - 2024-007-26
 ### Added 
 - Add "complete" field to show if the survey is completed [#61](https://github.com/rokwire/surveys-building-block/issues/61)

--- a/driver/web/apis_client.go
+++ b/driver/web/apis_client.go
@@ -150,9 +150,10 @@ func (h ClientAPIsHandler) getSurveys(l *logs.Log, r *http.Request, claims *toke
 		return l.HTTPResponseErrorAction(logutils.ActionGet, model.TypeSurvey, nil, err, http.StatusInternalServerError, true)
 	}
 
-	resData := getSurveysResData(surveys, surverysRsponse, completed)
+	list := getSurveysResData(surveys, surverysRsponse, completed)
+	respData := sortIfpublicIsTrue(list, public)
 
-	rdata, err := json.Marshal(resData)
+	rdata, err := json.Marshal(respData)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionMarshal, logutils.TypeResponseBody, nil, err, http.StatusInternalServerError, false)
 	}

--- a/driver/web/apis_client.go
+++ b/driver/web/apis_client.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -152,9 +151,6 @@ func (h ClientAPIsHandler) getSurveys(l *logs.Log, r *http.Request, claims *toke
 	}
 
 	resData := getSurveysResData(surveys, surverysRsponse, completed)
-	sort.Slice(resData, func(i, j int) bool {
-		return resData[i].DateCreated.After(resData[j].DateCreated)
-	})
 
 	rdata, err := json.Marshal(resData)
 	if err != nil {

--- a/driver/web/convertions_surveys.go
+++ b/driver/web/convertions_surveys.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"application/core/model"
+	"sort"
 	"time"
 )
 
@@ -139,9 +140,13 @@ func getSurveysResData(items []model.Survey, surveyResponses []model.SurveyRespo
 				Archived:                item.Archived,
 				EstimatedCompletionTime: item.EstimatedCompletionTime,
 				Completed:               &isCompleted,
+				DateCreated:             item.DateCreated,
 			})
 		}
 	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].DateCreated.After(list[j].DateCreated)
+	})
 
 	return list
 }

--- a/driver/web/convertions_surveys.go
+++ b/driver/web/convertions_surveys.go
@@ -150,3 +150,57 @@ func getSurveysResData(items []model.Survey, surveyResponses []model.SurveyRespo
 
 	return list
 }
+
+func sortIfpublicIsTrue(list []model.SurveysResponseData, public *bool) []model.SurveysResponseData {
+
+	if public == nil || !*public {
+		// If public is nil or false, just return the list as-is
+		return list
+	}
+
+	var incompleteSurveys, noEndDateSurveys, completedSurveys []model.SurveysResponseData
+
+	// Split surveys into categories based on completion status and end date
+	for _, survey := range list {
+		if survey.Completed != nil && *survey.Completed {
+			completedSurveys = append(completedSurveys, survey)
+		} else if survey.EndDate != nil {
+			incompleteSurveys = append(incompleteSurveys, survey)
+		} else {
+			noEndDateSurveys = append(noEndDateSurveys, survey)
+		}
+	}
+
+	// Sort incomplete surveys by end date (ascending)
+	sort.Slice(incompleteSurveys, func(i, j int) bool {
+		return incompleteSurveys[i].EndDate.Before(*incompleteSurveys[j].EndDate)
+	})
+
+	// Sort no-end-date surveys first by start date (descending) or by creation date if start date is missing
+	sort.Slice(noEndDateSurveys, func(i, j int) bool {
+		if noEndDateSurveys[i].StartDate != nil && noEndDateSurveys[j].StartDate != nil {
+			return noEndDateSurveys[i].StartDate.After(*noEndDateSurveys[j].StartDate)
+		}
+		if noEndDateSurveys[i].StartDate != nil {
+			return true
+		}
+		if noEndDateSurveys[j].StartDate != nil {
+			return false
+		}
+		return noEndDateSurveys[i].DateCreated.After(noEndDateSurveys[j].DateCreated)
+	})
+
+	// Sort completed surveys by estimated completion time (descending)
+	sort.Slice(completedSurveys, func(i, j int) bool {
+		if completedSurveys[i].EstimatedCompletionTime != nil && completedSurveys[j].EstimatedCompletionTime != nil {
+			return *completedSurveys[i].EstimatedCompletionTime > *completedSurveys[j].EstimatedCompletionTime
+		}
+		return completedSurveys[i].DateCreated.After(completedSurveys[j].DateCreated)
+	})
+
+	// Combine all sorted slices
+	result := append(incompleteSurveys, noEndDateSurveys...)
+	result = append(result, completedSurveys...)
+
+	return result
+}


### PR DESCRIPTION
## Description
Sort Order when showing all (public) surveys

1.1.1 Incompleted Surveys show first using survey end datetime and showing them in oldest to newest order. In other words the order is by what expires next onwards.

1.1.2 After listing surveys that meet the criteria in 1.1.1 above, next show uncompleted Surveys that never expire (do not have an end datetime). These would use start datetime and if missing creation datetime from newest to oldest.

1.1.3 Finally, show anything Completed is always shown at the bottom of the list using completion date time and from most recent to oldest.

**Resolves #64 
## Type of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
- [x] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [x] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.